### PR TITLE
CMakeLists Files need catkin_modules and updated references to cpp files in Hydro.

### DIFF
--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/basic_types.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/basic_types.h
@@ -133,7 +133,7 @@ namespace industrial_extrinsic_cal
      *   @param qz quaternion z value
      *   @param qw quaternion w value
     */
-    void getQuaternion(double &qx,  double &qy, double &qz, double &qw);
+    void getQuaternion(double &qx,  double &qy, double &qz, double &qw) const;
 
     /** @brief get the inverse of the pose_*/
     Pose6d getInverse() const;

--- a/industrial_extrinsic_cal/src/basic_types.cpp
+++ b/industrial_extrinsic_cal/src/basic_types.cpp
@@ -182,7 +182,7 @@ namespace industrial_extrinsic_cal
     ey = theta;
     ex = psi;
   }
-  void Pose6d::getQuaternion(double &qx,  double &qy, double &qz, double &qw)
+  void Pose6d::getQuaternion(double &qx,  double &qy, double &qz, double &qw) const
   {
     // the following was taken from ceres equivalent function
     double theta_squared = ax*ax + ay*ay + az*az;

--- a/target_finder/CMakeLists.txt
+++ b/target_finder/CMakeLists.txt
@@ -79,17 +79,10 @@ ENDIF (CERES_FOUND)
 # )
 
 ## Generate services in the 'srv' folder
- add_service_files(
+ add_service_files(DIRECTORY srv
    FILES
    target_locater.srv
  )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
 
 ## Generate added messages and services with any dependencies listed here
 generate_messages(
@@ -112,7 +105,7 @@ generate_messages(
 catkin_package(
    INCLUDE_DIRS include
 #  LIBRARIES 
-   CATKIN_DEPENDS roscpp std_msgs rosconsole std_srvs roslib 
+   CATKIN_DEPENDS roscpp std_msgs geometry_msgs rosconsole std_srvs roslib 
 #  DEPENDS 
 )
 


### PR DESCRIPTION
There was a small compile error that needed Pose6D::getQuaternion to have a const return. The prototype was changed in the header and source files of industrial_extrinsic_cal basic_types class.
